### PR TITLE
Replace for_each with count for aws_ssoadmin_account_assignment resource

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,13 +140,12 @@ Like this project? Please give it a ★ on [our GitHub](https://github.com/cloud
 Are you using this project or any of our other projects? Consider [leaving a testimonial][testimonial]. =)
 
 
+
 ## Related Projects
 
 Check out these related projects.
 
 - [terraform-null-label](https://github.com/cloudposse/terraform-null-label) - Terraform module designed to generate consistent names and tags for resources. Use terraform-null-label to implement a strict naming convention.
-
-
 
 
 ## References

--- a/modules/account-assignments/main.tf
+++ b/modules/account-assignments/main.tf
@@ -21,7 +21,7 @@ data "aws_identitystore_user" "this" {
 resource "aws_ssoadmin_account_assignment" "this" {
   count = length(var.account_assignments)
 
-  instance_arn       = local.identity_store_arn
+  instance_arn       = local.sso_instance_arn
   permission_set_arn = var.account_assignments[count.index]["permission_set_arn"]
 
   principal_id   = var.account_assignments[count.index]["principal_type"] == "GROUP" ? data.aws_identitystore_group.sso[var.account_assignments[count.index]["principal_name"]].id : data.aws_identitystore_user.sso[var.account_assignments[count.index]["principal_name"]].id


### PR DESCRIPTION
## what
* Replace `for_each`  with `count` for `aws_ssoadmin_account_assignment` resource
* Retrieve per iteration values using `count.index` from var.account_assignments
* Deprecate `assignment_map`

## why
* a.permission_set_arn is providing a unique value to the account_assignment name.
* However the permission_set_arn can not be determined until after the apply of the permission sets.
* Using a.permission_set_arn in account_assignments before the permission sets have been applied will result in the following error.
```
Error: Invalid for_each argument

  on .terraform/modules/sso_account_assignments/modules/account-assignments/main.tf line 30, in resource "aws_ssoadmin_account_assignment" "this":
  30:   for_each = local.assignment_map

The "for_each" value depends on resource attributes that cannot be determined
until apply, so Terraform cannot predict how many instances will be created.
To work around this, use the -target argument to first apply only the
resources that the for_each depends on.
```
## references
* Closes #12 

