### PR TITLE
fix/missing tags in permission set

### DIFF
--- a/modules/permission-sets/main.tf
+++ b/modules/permission-sets/main.tf
@@ -8,6 +8,7 @@ resource "aws_ssoadmin_permission_set" "this" {
   instance_arn     = local.sso_instance_arn
   relay_state      = each.value.relay_state != "" ? each.value.relay_state : null
   session_duration = each.value.session_duration != "" ? each.value.session_duration : null
+  tags             = each.value.tags != "" ? each.value.tags : null
 }
 
 #-----------------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
## what
* Adding tags to permission set resource in module permission-set. 

## why
* tags defined in complete example to supply custom tags but it is not set in `aws_ssoadmin_permission_set` resource which supports this attribute.

## references
* https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ssoadmin_permission_set#tags

