### PR TITLE
Prevent dynamic variable in for each key construct in assignment_map

### DIFF
--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -29,19 +29,22 @@ module "sso_account_assignments" {
 
   account_assignments = [
     {
-      account            = "111111111111", // Represents the "production" account
+      account_name       = "production",
+      account_id         = "111111111111",
       permission_set_arn = module.permission_sets.permission_sets["AdministratorAccess"].arn,
       principal_type     = "GROUP",
       principal_name     = "Administrators"
     },
     {
-      account            = "111111111111",
+      account_name       = "production",
+      account_id         = "111111111111",
       permission_set_arn = module.permission_sets.permission_sets["S3AdministratorAccess"].arn,
       principal_type     = "GROUP",
       principal_name     = "S3Adminstrators"
     },
     {
-      account            = "222222222222", // Represents the "Sandbox" account
+      account_name       = "sandbox",
+      account_id         = "222222222222",
       permission_set_arn = module.permission_sets.permission_sets["AdministratorAccess"].arn,
       principal_type     = "GROUP",
       principal_name     = "Developers"

--- a/modules/account-assignments/README.md
+++ b/modules/account-assignments/README.md
@@ -21,19 +21,22 @@ module "sso_account_assignments" {
 
   account_assignments = [
     {
-        account = "111111111111",
+        account_name = "foo",
+        account_id = "111111111111",
         permission_set_arn = "arn:aws:sso:::permissionSet/ssoins-0000000000000000/ps-31d20e5987f0ce66",
         principal_type = "GROUP",
         principal_name = "Administrators"
     },
     {
-        account = "111111111111",
+        account_name = "bar",
+        account_id = "111111111111",
         permission_set_arn = "arn:aws:sso:::permissionSet/ssoins-0000000000000000/ps-955c264e8f20fea3",
         principal_type = "GROUP",
         principal_name = "Developers"
     },
     {
-        account = "222222222222",
+        account_name = "baz",
+        account_id = "222222222222",
         permission_set_arn = "arn:aws:sso:::permissionSet/ssoins-0000000000000000/ps-31d20e5987f0ce66",
         principal_type = "GROUP",
         principal_name = "Developers"

--- a/modules/account-assignments/main.tf
+++ b/modules/account-assignments/main.tf
@@ -21,7 +21,7 @@ data "aws_identitystore_user" "this" {
 locals {
   assignment_map = {
     for a in var.account_assignments :
-    format("%v-%v-%v-%v", a.account, substr(a.principal_type, 0, 1), a.principal_name, a.permission_set_name) => a
+    format("%v-%v-%v-%v", a.account_name, substr(a.principal_type, 0, 1), a.principal_name, a.permission_set_name) => a
   }
 }
 
@@ -34,7 +34,7 @@ resource "aws_ssoadmin_account_assignment" "this" {
   principal_id   = each.value.principal_type == "GROUP" ? data.aws_identitystore_group.this[each.value.principal_name].id : data.aws_identitystore_user.this[each.value.principal_name].id
   principal_type = each.value.principal_type
 
-  target_id   = each.value.account
+  target_id   = each.value.account_id
   target_type = "AWS_ACCOUNT"
 }
 

--- a/modules/account-assignments/variables.tf
+++ b/modules/account-assignments/variables.tf
@@ -1,6 +1,7 @@
 variable "account_assignments" {
   type = list(object({
-    account             = string
+    account_name        = string
+    account_id          = string
     permission_set_name = string
     permission_set_arn  = string
     principal_name      = string


### PR DESCRIPTION
Prevent dynamic variable in for each key construct

## what
When you want to create accounts with sso account assignments in the same first terraform run you hit _for_each_ limitation with dynamic values that cannot be predicted during plan:

```
 Error: Invalid for_each argument

   on .terraform/modules/sso_account_assignments/modules/account-assignments/main.tf line 29, in resource "aws_ssoadmin_account_assignment" "this":
   29:   for_each = local.assignment_map

     local.assignment_map will be known only after apply

 The "for_each" value depends on resource attributes that cannot be determined until apply, so Terraform cannot predict how many instances will be created. To work around this, use the -target argument to first apply only the resources that the for_each depends on.
```

## why
This PR removes "dynamic" variable dependency in for_each key construction by eliminating the account id usage in the process of unique key creation. Account id is replaced with account name which should be static string (known before apply).

Changes:
* add new required input variable _account_name_
* rename account variable to _account_ to the _account_id_
* use _account_name_  instead of _account_id_  in assignment_map to prevent for_each limitation
* update docs and examples with new required/changed variables

This is breaking change and  manual intervention is needed:
* Make sure you modify input to the module with new required variable and rename account to the account_id
* Use _terraform state mv_ command to rename aws_ssoadmin_account_assignment resource blocks where account id should match account name
