### PR TITLE
allow multiple inline

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,7 +230,7 @@ In general, PRs are welcome. We follow the typical "fork-and-pull" Git workflow.
 
 ## Copyrights
 
-Copyright © 2020-2021 [Cloud Posse, LLC](https://cloudposse.com)
+Copyright © 2020-2022 [Cloud Posse, LLC](https://cloudposse.com)
 
 
 

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -12,18 +12,21 @@ module "permission_sets" {
       policy_attachments = ["arn:aws:iam::aws:policy/AdministratorAccess"]
     },
     {
-      name               = "S3AdministratorAccess",
-      description        = "Allow Full S3 Admininstrator access to the account",
-      relay_state        = "",
-      session_duration   = "",
-      tags               = {},
-      inline_policy      = data.aws_iam_policy_document.S3Access.json,
+      name             = "S3andIamAdministratorAccess",
+      description      = "Allow Full S3 and IAM Admininstrator access to the account",
+      relay_state      = "",
+      session_duration = "",
+      tags             = {},
+      inline_policy = [
+        { "policyname" : "s3_access", "policy_set" : data.aws_iam_policy_document.S3Access.json },
+        { "policyname" : "iam_access", "policy_set" : data.aws_iam_policy_document.IamAccess.json }
+      ],
       policy_attachments = []
     }
   ]
   context = module.this.context
 }
-
+# { "policyname" : "readonly", "policy_set" : data.template_file.read_only_inline_policy.rendered }, { "policyname" : "operational", "policy_set" : data.template_file.operational_access_inline_policy.rendered }
 module "sso_account_assignments" {
   source = "../../modules/account-assignments"
 
@@ -37,10 +40,10 @@ module "sso_account_assignments" {
     },
     {
       account             = "111111111111",
-      permission_set_arn  = module.permission_sets.permission_sets["S3AdministratorAccess"].arn,
-      permission_set_name = "S3AdministratorAccess",
+      permission_set_arn  = module.permission_sets.permission_sets["S3andIamAdministratorAccess"].arn,
+      permission_set_name = "S3andIamAdministratorAccess",
       principal_type      = "GROUP",
-      principal_name      = "S3Adminstrators"
+      principal_name      = "S3andIamAdminstrators"
     },
     {
       account             = "222222222222", # Represents the "Sandbox" account
@@ -64,6 +67,18 @@ data "aws_iam_policy_document" "S3Access" {
 
     resources = [
       "arn:aws:s3:::*",
+    ]
+  }
+}
+
+data "aws_iam_policy_document" "IamAccess" {
+  statement {
+    sid = "2"
+
+    actions = ["*"]
+
+    resources = [
+      "arn:aws:iam:::*",
     ]
   }
 }

--- a/modules/permission-sets/variables.tf
+++ b/modules/permission-sets/variables.tf
@@ -2,10 +2,9 @@ variable "permission_sets" {
   type = list(object({
     name               = string
     description        = string
-    relay_state        = string
     session_duration   = string
     tags               = map(string)
-    inline_policy      = string
+    inline_policy      = list(map(string))
     policy_attachments = list(string)
   }))
 


### PR DESCRIPTION
## what
Allow for multiple inline policies attached to a single resource. it is a breaking change:
- the way inline policies are referenced changes, because it needs additional information
- But, this allows you to create a single role that has multiple inline policies 


## why
This creates the possibility to e.g., always add readonly role, but also some additional permissions e.g., developer permissions and attach it to the same role. 


## references
None, just walked into this issue multiple times where we had slightly different readonly policy then aws, but next to it we also wanted to add things like 'lambda:Invoke' to the same role. This allows for that.

No need to merge it :) But it is used by us, and figured might as well provide you with the opportunity to add it. Curious what you think.  

