### PR TITLE
Replaced non-functional Github source statements with Terraform registry

### DIFF
--- a/.github/workflows/validate-codeowners.yml
+++ b/.github/workflows/validate-codeowners.yml
@@ -10,7 +10,7 @@ jobs:
     steps:
     - name: "Checkout source code at current commit"
       uses: actions/checkout@v2
-    - uses: mszostok/codeowners-validator@v0.5.0
+    - uses: mszostok/codeowners-validator@v0.7.1
       if: github.event.pull_request.head.repo.full_name == github.repository
       name: "Full check of CODEOWNERS"
       with:
@@ -18,10 +18,12 @@ jobs:
         # files so we can use the same CODEOWNERS file for Terraform and non-Terraform repos
         #   checks: "files,syntax,owners,duppatterns"
         checks: "syntax,owners,duppatterns"
+        owner_checker_allow_unowned_patterns: "false"
         # GitHub access token is required only if the `owners` check is enabled
         github_access_token: "${{ secrets.PUBLIC_REPO_ACCESS_TOKEN }}"
-    - uses: mszostok/codeowners-validator@v0.5.0
+    - uses: mszostok/codeowners-validator@v0.7.1
       if: github.event.pull_request.head.repo.full_name != github.repository
       name: "Syntax check of CODEOWNERS"
       with:
         checks: "syntax,duppatterns"
+        owner_checker_allow_unowned_patterns: "false"

--- a/README.md
+++ b/README.md
@@ -28,18 +28,18 @@
 
 -->
 
-This module configures [AWS Single Sign-On (SSO)](https://aws.amazon.com/single-sign-on/). AWS SSO makes it easy to 
-centrally manage access to multiple AWS accounts and business applications and provide users with single sign-on 
-access to all their assigned accounts and applications from one place. With AWS SSO, you can easily manage access and 
-user permissions to all of your accounts in AWS Organizations centrally. AWS SSO configures and maintains all the 
-necessary permissions for your accounts automatically, without requiring any additional setup in the individual 
-accounts. You can assign user permissions based on common job functions and customize these permissions to meet your 
-specific security requirements. AWS SSO also includes built-in integrations to many business applications, such as 
+This module configures [AWS Single Sign-On (SSO)](https://aws.amazon.com/single-sign-on/). AWS SSO makes it easy to
+centrally manage access to multiple AWS accounts and business applications and provide users with single sign-on
+access to all their assigned accounts and applications from one place. With AWS SSO, you can easily manage access and
+user permissions to all of your accounts in AWS Organizations centrally. AWS SSO configures and maintains all the
+necessary permissions for your accounts automatically, without requiring any additional setup in the individual
+accounts. You can assign user permissions based on common job functions and customize these permissions to meet your
+specific security requirements. AWS SSO also includes built-in integrations to many business applications, such as
 Salesforce, Box, and Microsoft 365.
 
-With AWS SSO, you can create and manage user identities in AWS SSO’s identity store, or easily connect to your 
-existing identity source, including Microsoft Active Directory, Okta Universal Directory, and Azure Active Directory 
-(Azure AD). AWS SSO allows you to select user attributes, such as cost center, title, or locale, from your identity 
+With AWS SSO, you can create and manage user identities in AWS SSO’s identity store, or easily connect to your
+existing identity source, including Microsoft Active Directory, Okta Universal Directory, and Azure Active Directory
+(Azure AD). AWS SSO allows you to select user attributes, such as cost center, title, or locale, from your identity
 source, and then use them for attribute-based access control in AWS.
 
 ---
@@ -76,10 +76,10 @@ It's 100% Open Source and licensed under the [APACHE2](LICENSE).
 
 
 
-This module contains two sub-modules that can be used in conjunction to provision AWS SSO Permission Sets and to 
+This module contains two sub-modules that can be used in conjunction to provision AWS SSO Permission Sets and to
 assign AWS SSO Users and Groups to Permissions Sets in accounts.
 
-- [modules/account-assignments](/modules/account-assignments) - a module for assigning users and groups to permission 
+- [modules/account-assignments](/modules/account-assignments) - a module for assigning users and groups to permission
 sets in particular accounts
 - [modules/permission-sets](/modules/permission-sets) - a module for provisioning AWS SSO permission sets
 

--- a/README.md
+++ b/README.md
@@ -28,18 +28,18 @@
 
 -->
 
-This module configures [AWS Single Sign-On (SSO)](https://aws.amazon.com/single-sign-on/). AWS SSO makes it easy to
-centrally manage access to multiple AWS accounts and business applications and provide users with single sign-on
-access to all their assigned accounts and applications from one place. With AWS SSO, you can easily manage access and
-user permissions to all of your accounts in AWS Organizations centrally. AWS SSO configures and maintains all the
-necessary permissions for your accounts automatically, without requiring any additional setup in the individual
-accounts. You can assign user permissions based on common job functions and customize these permissions to meet your
-specific security requirements. AWS SSO also includes built-in integrations to many business applications, such as
+This module configures [AWS Single Sign-On (SSO)](https://aws.amazon.com/single-sign-on/). AWS SSO makes it easy to 
+centrally manage access to multiple AWS accounts and business applications and provide users with single sign-on 
+access to all their assigned accounts and applications from one place. With AWS SSO, you can easily manage access and 
+user permissions to all of your accounts in AWS Organizations centrally. AWS SSO configures and maintains all the 
+necessary permissions for your accounts automatically, without requiring any additional setup in the individual 
+accounts. You can assign user permissions based on common job functions and customize these permissions to meet your 
+specific security requirements. AWS SSO also includes built-in integrations to many business applications, such as 
 Salesforce, Box, and Microsoft 365.
 
-With AWS SSO, you can create and manage user identities in AWS SSO’s identity store, or easily connect to your
-existing identity source, including Microsoft Active Directory, Okta Universal Directory, and Azure Active Directory
-(Azure AD). AWS SSO allows you to select user attributes, such as cost center, title, or locale, from your identity
+With AWS SSO, you can create and manage user identities in AWS SSO’s identity store, or easily connect to your 
+existing identity source, including Microsoft Active Directory, Okta Universal Directory, and Azure Active Directory 
+(Azure AD). AWS SSO allows you to select user attributes, such as cost center, title, or locale, from your identity 
 source, and then use them for attribute-based access control in AWS.
 
 ---
@@ -76,10 +76,10 @@ It's 100% Open Source and licensed under the [APACHE2](LICENSE).
 
 
 
-This module contains two sub-modules that can be used in conjunction to provision AWS SSO Permission Sets and to
+This module contains two sub-modules that can be used in conjunction to provision AWS SSO Permission Sets and to 
 assign AWS SSO Users and Groups to Permissions Sets in accounts.
 
-- [modules/account-assignments](/modules/account-assignments) - a module for assigning users and groups to permission
+- [modules/account-assignments](/modules/account-assignments) - a module for assigning users and groups to permission 
 sets in particular accounts
 - [modules/permission-sets](/modules/permission-sets) - a module for provisioning AWS SSO permission sets
 
@@ -230,7 +230,7 @@ In general, PRs are welcome. We follow the typical "fork-and-pull" Git workflow.
 
 ## Copyrights
 
-Copyright © 2020-2021 [Cloud Posse, LLC](https://cloudposse.com)
+Copyright © 2020-2022 [Cloud Posse, LLC](https://cloudposse.com)
 
 
 

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -1,5 +1,6 @@
 module "permission_sets" {
-  source = "../../modules/permission-sets"
+  source  = "cloudposse/sso/aws"
+  version = "v0.6.2"
 
   permission_sets = [
     {
@@ -25,7 +26,8 @@ module "permission_sets" {
 }
 
 module "sso_account_assignments" {
-  source = "../../modules/account-assignments"
+  source  = "cloudposse/sso/aws"
+  version = "v0.6.2"
 
   account_assignments = [
     {

--- a/modules/account-assignments/README.md
+++ b/modules/account-assignments/README.md
@@ -17,7 +17,8 @@ For a complete example, see [examples/complete](/examples/complete).
 
 ```hcl
 module "sso_account_assignments" {
-  source = "https://github.com/cloudposse/terraform-aws-sso.git//modules/account-assignments?ref=master"
+  source  = "cloudposse/sso/aws"
+  version = "v0.6.2"
 
   account_assignments = [
     {

--- a/modules/permission-sets/README.md
+++ b/modules/permission-sets/README.md
@@ -13,7 +13,8 @@ For a complete example, see [examples/complete](/examples/complete).
 
 ```hcl
 module "permission_sets" {
-  source = "https://github.com/cloudposse/terraform-aws-sso.git//modules/permission-sets?ref=master"
+  source  = "cloudposse/sso/aws"
+  version = "v0.6.2"
 
   permission_sets = [
     {


### PR DESCRIPTION
## what
 * This change replaces source references (in documentation / examples only) to Github with references to the Terraform registry, inc version number in all examples.

 * Also removed trailing spaces from a few places in the documentation.

## why
 * Syntax for sourcing module via Github was failing when attempting to specify a tagged release (e.g. "?ref=v0.6.2").
