### PR TITLE
Add customer managed policy attachments to permissionsets

### DIFF
--- a/.github/auto-release.yml
+++ b/.github/auto-release.yml
@@ -17,7 +17,6 @@ version-resolver:
     - 'bugfix'
     - 'bug'
     - 'hotfix'
-    - 'no-release'
   default: 'minor'
 
 categories:

--- a/README.md
+++ b/README.md
@@ -299,7 +299,7 @@ Check out [our other projects][github], [follow us on twitter][twitter], [apply 
 
 [![README Footer][readme_footer_img]][readme_footer_link]
 [![Beacon][beacon]][website]
-
+<!-- markdownlint-disable -->
   [logo]: https://cloudposse.com/logo-300x69.svg
   [docs]: https://cpco.io/docs?utm_source=github&utm_medium=readme&utm_campaign=cloudposse/terraform-aws-sso&utm_content=docs
   [website]: https://cpco.io/homepage?utm_source=github&utm_medium=readme&utm_campaign=cloudposse/terraform-aws-sso&utm_content=website
@@ -330,3 +330,4 @@ Check out [our other projects][github], [follow us on twitter][twitter], [apply 
   [share_googleplus]: https://plus.google.com/share?url=https://github.com/cloudposse/terraform-aws-sso
   [share_email]: mailto:?subject=terraform-aws-sso&body=https://github.com/cloudposse/terraform-aws-sso
   [beacon]: https://ga-beacon.cloudposse.com/UA-76589703-4/cloudposse/terraform-aws-sso?pixel&cs=github&cm=readme&an=terraform-aws-sso
+<!-- markdownlint-restore -->

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -10,15 +10,20 @@ module "permission_sets" {
       tags               = {},
       inline_policy      = "",
       policy_attachments = ["arn:aws:iam::aws:policy/AdministratorAccess"]
+      customer_managed_policy_attachments = [{
+        name = aws_iam_policy.S3Access.name
+        path = aws_iam_policy.S3Access.path
+      }]
     },
     {
-      name               = "S3AdministratorAccess",
-      description        = "Allow Full S3 Admininstrator access to the account",
-      relay_state        = "",
-      session_duration   = "",
-      tags               = {},
-      inline_policy      = data.aws_iam_policy_document.S3Access.json,
-      policy_attachments = []
+      name                                = "S3AdministratorAccess",
+      description                         = "Allow Full S3 Admininstrator access to the account",
+      relay_state                         = "",
+      session_duration                    = "",
+      tags                                = {},
+      inline_policy                       = data.aws_iam_policy_document.S3Access.json,
+      policy_attachments                  = []
+      customer_managed_policy_attachments = []
     }
   ]
   context = module.this.context
@@ -66,4 +71,13 @@ data "aws_iam_policy_document" "S3Access" {
       "arn:aws:s3:::*",
     ]
   }
+}
+
+#-----------------------------------------------------------------------------------------------------------------------
+# CREATE SOME IAM POLCIES TO ATTACH AS MANAGED
+#-----------------------------------------------------------------------------------------------------------------------
+resource "aws_iam_policy" "S3Access" {
+  name   = "S3Access"
+  path   = "/"
+  policy = data.aws_iam_policy_document.S3Access.json
 }

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -80,4 +80,5 @@ resource "aws_iam_policy" "S3Access" {
   name   = "S3Access"
   path   = "/"
   policy = data.aws_iam_policy_document.S3Access.json
+  tags   = module.this.tags
 }

--- a/modules/permission-sets/README.md
+++ b/modules/permission-sets/README.md
@@ -18,20 +18,26 @@ module "permission_sets" {
   permission_sets = [
     {
       name               = "AdministratorAccess",
-      description        = "Give a user full admininstrator access to an account",
+      description        = "Allow Full Access to the account",
       relay_state        = "",
       session_duration   = "",
       tags               = {},
       inline_policy      = "",
       policy_attachments = ["arn:aws:iam::aws:policy/AdministratorAccess"]
+      customer_managed_policy_attachments = [{
+        name = aws_iam_policy.S3Access.name
+        path = aws_iam_policy.S3Access.path
+      }]
     },
-    { name               = "S3AdministratorAccess",
-      description        = "Give a user full S3 administrator access",
-      relay_state        = "",
-      session_duration   = "",
-      tags               = {},
-      inline_policy      = data.aws_iam_policy_document.S3Access.json,
-      policy_attachments = []
+    {
+      name                                = "S3AdministratorAccess",
+      description                         = "Allow Full S3 Admininstrator access to the account",
+      relay_state                         = "",
+      session_duration                    = "",
+      tags                                = {},
+      inline_policy                       = data.aws_iam_policy_document.S3Access.json,
+      policy_attachments                  = []
+      customer_managed_policy_attachments = []
     }
   ]
   context = module.this.context
@@ -48,4 +54,11 @@ data "aws_iam_policy_document" "S3Access" {
     ]
   }
 }
+
+resource "aws_iam_policy" "S3Access" {
+  name   = "S3Access"
+  path   = "/"
+  policy = data.aws_iam_policy_document.S3Access.json
+}
+
 ```

--- a/modules/permission-sets/README.md
+++ b/modules/permission-sets/README.md
@@ -59,6 +59,7 @@ resource "aws_iam_policy" "S3Access" {
   name   = "S3Access"
   path   = "/"
   policy = data.aws_iam_policy_document.S3Access.json
+  tags   = module.this.tags
 }
 
 ```

--- a/modules/permission-sets/main.tf
+++ b/modules/permission-sets/main.tf
@@ -78,5 +78,4 @@ locals {
   customer_managed_policy_attachments_map = {
     for policy in local.managed_policy_attachments : "${policy.policy_set}.${policy.policy_path}${policy.policy_name}" => policy
   }
-
 }

--- a/modules/permission-sets/main.tf
+++ b/modules/permission-sets/main.tf
@@ -32,6 +32,19 @@ resource "aws_ssoadmin_managed_policy_attachment" "this" {
 }
 
 #-----------------------------------------------------------------------------------------------------------------------
+# ATTACH CUSTOMER MANAGED POLICIES
+#-----------------------------------------------------------------------------------------------------------------------
+resource "aws_ssoadmin_customer_managed_policy_attachment" "this" {
+  for_each           = local.customer_managed_policy_attachments_map
+  instance_arn       = local.sso_instance_arn
+  permission_set_arn = aws_ssoadmin_permission_set.this[each.value.policy_set].arn
+  customer_managed_policy_reference {
+    name = each.value.policy_name
+    path = each.value.policy_path
+  }
+}
+
+#-----------------------------------------------------------------------------------------------------------------------
 # LOCAL VARIABLES AND DATA SOURCES
 #-----------------------------------------------------------------------------------------------------------------------
 data "aws_ssoadmin_instances" "this" {}
@@ -52,4 +65,18 @@ locals {
   managed_policy_attachments_map = {
     for policy in local.managed_policy_attachments : "${policy.policy_set}.${policy.policy_arn}" => policy
   }
+  customer_managed_policy_map = { for ps in var.permission_sets : ps.name => ps.customer_managed_policy_attachments if length(ps.customer_managed_policy_attachments) > 0 }
+  customer_managed_policy_attachments = flatten([
+    for ps_name, policy_list in local.customer_managed_policy_map : [
+      for policy in policy_list : {
+        policy_set  = ps_name
+        policy_name = policy.name
+        policy_path = policy.path
+      }
+    ]
+  ])
+  customer_managed_policy_attachments_map = {
+    for policy in local.managed_policy_attachments : "${policy.policy_set}.${policy.policy_path}${policy.policy_name}" => policy
+  }
+
 }

--- a/modules/permission-sets/variables.tf
+++ b/modules/permission-sets/variables.tf
@@ -7,6 +7,10 @@ variable "permission_sets" {
     tags               = map(string)
     inline_policy      = string
     policy_attachments = list(string)
+    customer_managed_policy_attachments = list(object({
+      name = string
+      path = string
+    }))
   }))
 
   default = []

--- a/modules/permission-sets/versions.tf
+++ b/modules/permission-sets/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 3.26.0"
+      version = ">= 4.30.0"
     }
   }
 }


### PR DESCRIPTION
## what

- Add support for attaching customer managed policies to permissionsets

This is a breaking change that requires a new AWS provider version: https://github.com/hashicorp/terraform-provider-aws/releases/tag/v4.30.0

## why

- Inline policies have a maximum limit.
- Ease management with customer managed policies

## references

- https://github.com/hashicorp/terraform-provider-aws/releases/tag/v4.30.0
