### PR TITLE
Fix map mismatch

### DIFF
--- a/modules/permission-sets/main.tf
+++ b/modules/permission-sets/main.tf
@@ -76,6 +76,6 @@ locals {
     ]
   ])
   customer_managed_policy_attachments_map = {
-    for policy in local.managed_policy_attachments : "${policy.policy_set}.${policy.policy_path}${policy.policy_name}" => policy
+    for policy in local.customer_managed_policy_attachments : "${policy.policy_set}.${policy.policy_path}${policy.policy_name}" => policy
   }
 }


### PR DESCRIPTION
## what
* Fixed failures in the module due to a mismatch in the maps.

## why
* Currently the module does not work. This resolved the issue. 

## references
- Previous PR https://github.com/cloudposse/terraform-aws-sso/pull/30

## errata
It would probably also be helpful to have a note in `README.md` about the need for policies to exist in the target account to be associated. The provided example is a little misleading for that reason. 