### PR TITLE
add account key identifier to plan unknown account ids

### DIFF
--- a/modules/account-assignments/main.tf
+++ b/modules/account-assignments/main.tf
@@ -21,7 +21,7 @@ data "aws_identitystore_user" "this" {
 locals {
   assignment_map = {
     for a in var.account_assignments :
-    format("%v-%v-%v-%v", a.account, substr(a.principal_type, 0, 1), a.principal_name, a.permission_set_name) => a
+    format("%v-%v-%v-%v", a.account_key, substr(a.principal_type, 0, 1), a.principal_name, a.permission_set_name) => a
   }
 }
 
@@ -34,7 +34,7 @@ resource "aws_ssoadmin_account_assignment" "this" {
   principal_id   = each.value.principal_type == "GROUP" ? data.aws_identitystore_group.this[each.value.principal_name].id : data.aws_identitystore_user.this[each.value.principal_name].id
   principal_type = each.value.principal_type
 
-  target_id   = each.value.account
+  target_id   = each.value.account_id
   target_type = "AWS_ACCOUNT"
 }
 

--- a/modules/account-assignments/variables.tf
+++ b/modules/account-assignments/variables.tf
@@ -1,6 +1,7 @@
 variable "account_assignments" {
   type = list(object({
-    account             = string
+    account_id          = string
+    account_key         = string
     permission_set_name = string
     permission_set_arn  = string
     principal_name      = string


### PR DESCRIPTION
## what
* Add account_key identifier to account-assignments
* Use account_key instead of account_id as key in for_each of resources

## why
* Using the account_id inside the for_each disallows creating these accounts in the same terraform module, because the plan is not statically known

