### PR TITLE
feat: allow to safely depend on other resources to read from the identity store

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,72 @@
+---
+name: Bug report
+description: Create a report to help us improve
+labels: ["bug"]
+assignees: [""]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Found a bug?
+        
+        Please checkout our [Slack Community](https://slack.cloudposse.com)
+        or visit our [Slack Archive](https://archive.sweetops.com/).
+
+        [![Slack Community](https://slack.cloudposse.com/badge.svg)](https://slack.cloudposse.com)
+
+  - type: textarea
+    id: concise-description
+    attributes:
+      label: Describe the Bug
+      description: A clear and concise description of what the bug is.
+      placeholder: What is the bug about?
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected Behavior
+      description: A clear and concise description of what you expected.
+      placeholder: What happened?
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproduction-steps
+    attributes:
+      label: Steps to Reproduce
+      description: Steps to reproduce the behavior.
+      placeholder: How do we reproduce it?
+    validations:
+      required: true
+
+  - type: textarea
+    id: screenshots
+    attributes:
+      label: Screenshots
+      description: If applicable, add screenshots or logs to help explain.
+    validations:
+      required: false
+
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: Anything that will help us triage the bug.
+      placeholder: |
+        - OS: [e.g. Linux, OSX, WSL, etc]
+        - Version [e.g. 10.15]
+        - Module version
+        - Terraform version
+    validations:
+      required: false
+
+  - type: textarea
+    id: additional
+    attributes:
+      label: Additional Context
+      description: |
+        Add any other context about the problem here.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,71 @@
+---
+name: Feature Request
+description: Suggest an idea for this project
+labels: ["feature request"]
+assignees: [""]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Have a question?
+        
+        Please checkout our [Slack Community](https://slack.cloudposse.com)
+        or visit our [Slack Archive](https://archive.sweetops.com/).
+
+        [![Slack Community](https://slack.cloudposse.com/badge.svg)](https://slack.cloudposse.com)
+
+  - type: textarea
+    id: concise-description
+    attributes:
+      label: Describe the Feature
+      description: A clear and concise description of what the feature is.
+      placeholder: What is the feature about?
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected Behavior
+      description: A clear and concise description of what you expected.
+      placeholder: What happened?
+    validations:
+      required: true
+
+  - type: textarea
+    id: use-case
+    attributes:
+      label: Use Case
+      description: |
+        Is your feature request related to a problem/challenge you are trying
+        to solve?
+        
+        Please provide some additional context of why this feature or
+        capability will be valuable.
+    validations:
+      required: true
+
+  - type: textarea
+    id: ideal-solution
+    attributes:
+      label: Describe Ideal Solution
+      description: A clear and concise description of what you want to happen.
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives-considered
+    attributes:
+      label: Alternatives Considered
+      description: Explain alternative solutions or features considered.
+    validations:
+      required: false
+
+  - type: textarea
+    id: additional
+    attributes:
+      label: Additional Context
+      description: |
+        Add any other context about the problem here.
+    validations:
+      required: false

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,13 +1,21 @@
 ## what
-* Describe high-level what changed as a result of these commits (i.e. in plain-english, what do these changes mean?)
-* Use bullet points to be concise and to the point.
+
+<!--
+- Describe high-level what changed as a result of these commits (i.e. in plain-english, what do these changes mean?)
+- Use bullet points to be concise and to the point.
+-->
 
 ## why
-* Provide the justifications for the changes (e.g. business case). 
-* Describe why these changes were made (e.g. why do these commits fix the problem?)
-* Use bullet points to be concise and to the point.
+
+<!--
+- Provide the justifications for the changes (e.g. business case). 
+- Describe why these changes were made (e.g. why do these commits fix the problem?)
+- Use bullet points to be concise and to the point.
+-->
 
 ## references
-* Link to any supporting github issues or helpful documentation to add some context (e.g. stackoverflow). 
-* Use `closes #123`, if this PR closes a GitHub issue `#123`
 
+<!--
+- Link to any supporting github issues or helpful documentation to add some context (e.g. stackoverflow). 
+- Use `closes #123`, if this PR closes a GitHub issue `#123`
+-->

--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions-ecosystem/action-get-merged-pull-request@v1
         id: get-merged-pull-request
         with:
-          github_token: ${{ secrets.PUBLIC_REPO_ACCESS_TOKEN }}
+          github_token: ${{ secrets.REPO_ACCESS_TOKEN }}
       # Drafts your next Release notes as Pull Requests are merged into "main"
       - uses: release-drafter/release-drafter@v5
         with:
@@ -23,4 +23,4 @@ jobs:
           prerelease: false
           config-name: auto-release.yml
         env:
-          GITHUB_TOKEN: ${{ secrets.PUBLIC_REPO_ACCESS_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.REPO_ACCESS_TOKEN }}

--- a/.github/workflows/validate-codeowners.yml
+++ b/.github/workflows/validate-codeowners.yml
@@ -10,6 +10,7 @@ jobs:
     steps:
     - name: "Checkout source code at current commit"
       uses: actions/checkout@v2
+      # Leave pinned at 0.7.1 until https://github.com/mszostok/codeowners-validator/issues/173 is resolved
     - uses: mszostok/codeowners-validator@v0.7.1
       if: github.event.pull_request.head.repo.full_name == github.repository
       name: "Full check of CODEOWNERS"

--- a/.github/workflows/validate-codeowners.yml
+++ b/.github/workflows/validate-codeowners.yml
@@ -21,7 +21,7 @@ jobs:
         checks: "syntax,owners,duppatterns"
         owner_checker_allow_unowned_patterns: "false"
         # GitHub access token is required only if the `owners` check is enabled
-        github_access_token: "${{ secrets.PUBLIC_REPO_ACCESS_TOKEN }}"
+        github_access_token: "${{ secrets.REPO_ACCESS_TOKEN }}"
     - uses: mszostok/codeowners-validator@v0.7.1
       if: github.event.pull_request.head.repo.full_name != github.repository
       name: "Syntax check of CODEOWNERS"

--- a/README.md
+++ b/README.md
@@ -230,7 +230,7 @@ In general, PRs are welcome. We follow the typical "fork-and-pull" Git workflow.
 
 ## Copyrights
 
-Copyright © 2020-2022 [Cloud Posse, LLC](https://cloudposse.com)
+Copyright © 2020-2023 [Cloud Posse, LLC](https://cloudposse.com)
 
 
 

--- a/modules/account-assignments/main.tf
+++ b/modules/account-assignments/main.tf
@@ -1,6 +1,6 @@
 resource "null_resource" "dependency" {
   triggers = {
-    dependency_id = join(",", var.wait_group_creation)
+    dependency_id = join(",", var.identitystore_group_depends_on)
   }
 }
 

--- a/modules/account-assignments/main.tf
+++ b/modules/account-assignments/main.tf
@@ -1,3 +1,9 @@
+resource "null_resource" "dependency" {
+  triggers = {
+    dependency_id = join(",", var.wait_group_creation)
+  }
+}
+
 data "aws_identitystore_group" "this" {
   for_each          = local.group_list
   identity_store_id = local.identity_store_id
@@ -6,6 +12,8 @@ data "aws_identitystore_group" "this" {
     attribute_path  = "DisplayName"
     attribute_value = each.key
   }
+
+  depends_on = [null_resource.dependency]
 }
 
 data "aws_identitystore_user" "this" {
@@ -16,6 +24,8 @@ data "aws_identitystore_user" "this" {
     attribute_path  = "UserName"
     attribute_value = each.key
   }
+
+  depends_on = [null_resource.dependency]
 }
 
 locals {

--- a/modules/account-assignments/variables.tf
+++ b/modules/account-assignments/variables.tf
@@ -7,3 +7,9 @@ variable "account_assignments" {
     principal_type      = string
   }))
 }
+
+variable "wait_group_creation" {
+  description = "A list of parameters to use for data resources to depend on"
+  type        = list(string)
+  default     = []
+}

--- a/modules/account-assignments/variables.tf
+++ b/modules/account-assignments/variables.tf
@@ -8,8 +8,8 @@ variable "account_assignments" {
   }))
 }
 
-variable "wait_group_creation" {
-  description = "A list of parameters to use for data resources to depend on"
+variable "identitystore_group_depends_on" {
+  description = "A list of parameters to use for data resources to depend on. This is a workaround to avoid module depends_on as that will recreate the module resources in many unexpected situations"
   type        = list(string)
   default     = []
 }


### PR DESCRIPTION
## what
This adds a workaround for the `depends_on` issue with modules and data sources.

* Added a wait for variable
* Added a `null_resource` to use for `depends_on` for the data resource

If the PR is acceptable, we can add an example usage to avoid the recreation of resources.

## why
* When creating a user group via an external source that syncs with AWS SSO, we need to wait for it to finish before reading the groups from the identity store
* Adding a `depends_on` to a module can create a situation that every change to the dependee will recreate ALL the resources of the module which is super bad

In my case I have to following code:
```
data "okta_user" "this" {
  for_each = toset(local.users_list)

  user_id = each.value
}

resource "okta_group" "this" {
  for_each = local.accounts_list

  name        = each.value.group_name
  description = "description"
}

resource "okta_group_memberships" "this" {
  for_each = local.accounts_list

  group_id = okta_group.this[each.key].id
  users    = [for u in each.value.users : data.okta_user.this[u].id]
}


module "permission_sets" {
  source  = "cloudposse/sso/aws//modules/permission-sets"
  version = "0.6.1"

  permission_sets = [
    for a in local.accounts_list : {
      name               = a.permission_set_name
      description        = "some desc"
      relay_state        = ""
      session_duration   = "PT2H"
      tags               = local.permission_set_tags
      inline_policy      = ""
      policy_attachments = ["arn:aws:iam::aws:policy/XXXXX"]
    }
  ]
}

module "account_assignments" {
  source  = "cloudposse/sso/aws//modules/account-assignments"
  version = "0.6.1"

  depends_on = [
    okta_group.this,
  ]

  account_assignments = concat([
    for a in local.accounts_list : {
      account             = a.id
      permission_set_arn  = module.permission_sets.permission_sets[a.permission_set_name].arn
      permission_set_name = "${a.name}-${a.role}"
      principal_type      = "GROUP",
      principal_name      = a.group_name
    }
  ])
}
```

When ever I need to change the `local.accounts_list` it causes ALL the assignments to be recreated, disconnecting users and causing mayhem...

With the proposed change I need to change the `account_assignments` module and now I can add or remove accounts safely:

```
module "account_assignments" {
  source = "path/to/terraform-aws-sso/modules/account-assignments"

  for_each = local.accounts_list

  wait_group_creation = okta_group.this[each.value.name].id

  account_assignments = [
    {
      account             = each.value.id
      permission_set_arn  = module.permission_sets.permission_sets[each.value.permission_set_name].arn
      permission_set_name = "${each.value.name}-${each.value.role}"
      principal_type      = "GROUP",
      principal_name      = each.value.group_name
    }
  ]
}
```


## references
* https://itnext.io/beware-of-depends-on-for-modules-it-might-bite-you-da4741caac70
* https://medium.com/hashicorp-engineering/creating-module-dependencies-in-terraform-0-13-4322702dac4a

