### PR TITLE
Fix AWS provider 4.40 deprecation warnings

### DIFF
--- a/modules/account-assignments/main.tf
+++ b/modules/account-assignments/main.tf
@@ -8,9 +8,11 @@ data "aws_identitystore_group" "this" {
   for_each          = local.group_list
   identity_store_id = local.identity_store_id
 
-  filter {
-    attribute_path  = "DisplayName"
-    attribute_value = each.key
+  alternate_identifier {
+    unique_attribute {
+      attribute_path  = "DisplayName"
+      attribute_value = each.key
+    }
   }
 
   depends_on = [null_resource.dependency]

--- a/modules/account-assignments/versions.tf
+++ b/modules/account-assignments/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 3.26.0"
+      version = ">= 4.40.0"
     }
   }
 }


### PR DESCRIPTION
## what
Fix the deprecation warnings as described here: https://github.com/hashicorp/terraform-provider-aws/releases/tag/v4.40.0

Based on PR #33 so that should be merged first.

## why
Otherwise there are deprecation warnings...

## references
* https://github.com/hashicorp/terraform-provider-aws/releases/tag/v4.40.0
* https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/identitystore_group#filter
* closes #34 

