### PR TITLE
Add missing permission_set_name to account_assigments README.md

### DIFF
--- a/.github/workflows/validate-codeowners.yml
+++ b/.github/workflows/validate-codeowners.yml
@@ -10,6 +10,7 @@ jobs:
     steps:
     - name: "Checkout source code at current commit"
       uses: actions/checkout@v2
+      # Leave pinned at 0.7.1 until https://github.com/mszostok/codeowners-validator/issues/173 is resolved
     - uses: mszostok/codeowners-validator@v0.7.1
       if: github.event.pull_request.head.repo.full_name == github.repository
       name: "Full check of CODEOWNERS"

--- a/README.md
+++ b/README.md
@@ -230,7 +230,7 @@ In general, PRs are welcome. We follow the typical "fork-and-pull" Git workflow.
 
 ## Copyrights
 
-Copyright © 2020-2022 [Cloud Posse, LLC](https://cloudposse.com)
+Copyright © 2020-2023 [Cloud Posse, LLC](https://cloudposse.com)
 
 
 

--- a/modules/account-assignments/README.md
+++ b/modules/account-assignments/README.md
@@ -23,18 +23,21 @@ module "sso_account_assignments" {
     {
         account = "111111111111",
         permission_set_arn = "arn:aws:sso:::permissionSet/ssoins-0000000000000000/ps-31d20e5987f0ce66",
+        permission_set_name = "Administrators",
         principal_type = "GROUP",
         principal_name = "Administrators"
     },
     {
         account = "111111111111",
         permission_set_arn = "arn:aws:sso:::permissionSet/ssoins-0000000000000000/ps-955c264e8f20fea3",
+        permission_set_name = "Developers",
         principal_type = "GROUP",
         principal_name = "Developers"
     },
     {
         account = "222222222222",
         permission_set_arn = "arn:aws:sso:::permissionSet/ssoins-0000000000000000/ps-31d20e5987f0ce66",
+        permission_set_name = "Developers",
         principal_type = "GROUP",
         principal_name = "Developers"
     },


### PR DESCRIPTION
## what
This pull request adds a missing `permission_set_name` attribute to `README.md `within the `account_assignments` module. It's exactly related to this open draft https://github.com/cloudposse/terraform-aws-sso/pull/28 that however, due to a lack of activity in the meantime, it may have caused confusion as I personally was unable to find it documented. I test the module again and it worked with the missing attribute.

## why
I recently went through the process of testing one of the modules and noticed that an attribute was missing from the README documentation. To prevent confusion for future users, I propose updating the README to include this missing information.

## references
* None, just went through testing one of the module and I found out that adding the missing documented attribute fixed the issue. 

