### PR TITLE
Adding two modules to create and maintain users, groups and group memberships.

### DIFF
--- a/modules/group-membership/README.md
+++ b/modules/group-membership/README.md
@@ -1,0 +1,56 @@
+# AWS SSO Group Membership Module
+
+This module assigns SSO Users to SSO Groups in the [AWS SSO Identity Source](https://docs.aws.amazon.com/singlesignon/latest/userguide/manage-your-identity-source.html).
+
+
+## Usage
+
+For example:
+
+```hcl
+locals {
+  users = {
+    User1 = {
+      first_name = "Michael",
+      last_name  = "Segal",
+      email      = "micheal.s@domain.com"
+      groups     = ["Admin", "Dev"]
+    }
+    User2 = {
+      first_name = "Lisa",
+      last_name  = "Hamilton",
+      email      = "lisa.h@domain.com"
+      groups     = []
+    }
+  }
+  groups = {
+    admin = {
+      display_name = "Admin",
+      description  = "Admin Group"
+    }
+    dev = {
+      display_name = "Dev",
+      description  = "Dev Group"
+    }
+    read-only = {
+      display_name = "ReadOnly",
+      description  = "Read Only Group"
+    }
+  }
+}
+
+module "identity-store" {
+  source = "../terraform-aws-sso/modules/identity-store"
+  users  = local.users
+  groups = local.groups
+}
+
+module "group-memberhip" {
+  source            = "../terraform-aws-sso/modules/group-membership"
+  for_each          = local.users
+  groups_member     = local.users[each.key].groups
+  groups_created    = module.identity-store.groups
+  member_id         = module.identity-store.users[each.key].user_id
+}
+
+```

--- a/modules/group-membership/main.tf
+++ b/modules/group-membership/main.tf
@@ -1,0 +1,12 @@
+resource "aws_identitystore_group_membership" "this" {
+  for_each          = var.groups_member
+  identity_store_id = local.sso_identity_store_id
+  group_id          = [for group in var.groups_created : group.group_id if group.display_name == each.value][0]
+  member_id         = var.member_id
+}
+
+data "aws_ssoadmin_instances" "this" {}
+
+locals {
+  sso_identity_store_id = tolist(data.aws_ssoadmin_instances.this.identity_store_ids)[0]
+}

--- a/modules/group-membership/variables.tf
+++ b/modules/group-membership/variables.tf
@@ -1,0 +1,16 @@
+variable "member_id" {
+  type        = string
+  description = "The identifier of the user in AWS SSO"
+}
+
+variable "groups_created" {
+  type = map(object({
+    group_id   = string
+    display_name = string}))
+  description = "Groups created by the identity-store module"
+}
+
+variable "groups_member" {
+  type = set(string)
+  description = "Groups that each user is a member of"
+}

--- a/modules/group-membership/versions.tf
+++ b/modules/group-membership/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 0.13.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 4.40.0"
+    }
+  }
+}

--- a/modules/identity-store/README.md
+++ b/modules/identity-store/README.md
@@ -1,0 +1,46 @@
+# AWS SSO Identity Store Module
+
+This module creates SSO Users and Groups in the [AWS SSO Identity Source](https://docs.aws.amazon.com/singlesignon/latest/userguide/manage-your-identity-source.html).
+
+
+## Usage
+
+For example:
+
+```hcl
+locals {
+  users = {
+    User1 = {
+      first_name = "Michael",
+      last_name  = "Segal",
+      email      = "micheal.s@domain.com"
+    }
+    User2 = {
+      first_name = "Lisa",
+      last_name  = "Hamilton",
+      email      = "lisa.h@domain.com"
+    }
+  }
+  groups = {
+    admin = {
+      display_name = "Admin",
+      description  = "Admin Group"
+    }
+    dev = {
+      display_name = "Dev",
+      description  = "Dev Group"
+    }
+    read-only = {
+      display_name = "ReadOnly",
+      description  = "Read Only Group"
+    }
+  }
+}
+
+module "identity-store" {
+  source = "../terraform-aws-sso/modules/identity-store"
+  users  = local.users
+  groups = local.groups
+}
+
+```

--- a/modules/identity-store/main.tf
+++ b/modules/identity-store/main.tf
@@ -1,0 +1,31 @@
+
+resource "aws_identitystore_user" "this" {
+  for_each          = var.users
+  identity_store_id = local.sso_identity_store_id
+
+  display_name = "${each.value.first_name} ${each.value.last_name}"
+  user_name    = each.value.email
+
+  name {
+    given_name  = each.value.first_name
+    family_name = each.value.last_name
+  }
+
+  emails {
+    value   = each.value.email
+    primary = true
+  }
+}
+
+resource "aws_identitystore_group" "this" {
+  for_each          = var.groups
+  display_name      = each.value.display_name
+  description       = each.value.description
+  identity_store_id = local.sso_identity_store_id
+}
+
+data "aws_ssoadmin_instances" "this" {}
+
+locals {
+  sso_identity_store_id = tolist(data.aws_ssoadmin_instances.this.identity_store_ids)[0]
+}

--- a/modules/identity-store/outputs.tf
+++ b/modules/identity-store/outputs.tf
@@ -1,0 +1,7 @@
+output "users" {
+  value = aws_identitystore_user.this
+}
+
+output "groups" {
+  value = aws_identitystore_group.this
+}

--- a/modules/identity-store/variables.tf
+++ b/modules/identity-store/variables.tf
@@ -1,0 +1,14 @@
+variable "users" {
+  type = map(object({
+    first_name = string
+    last_name  = string
+    email      = string
+  }))
+}
+
+variable "groups" {
+  type = map(object({
+    display_name = string
+    description  = string
+  }))
+}

--- a/modules/identity-store/versions.tf
+++ b/modules/identity-store/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 0.13.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 4.40.0"
+    }
+  }
+}


### PR DESCRIPTION
## what

Adding a new module called **Identity Store**:

This module creates SSO Users and Groups in the [AWS SSO Identity Source](https://docs.aws.amazon.com/singlesignon/latest/userguide/manage-your-identity-source.html).

Adding a new module called **Group Membership**:

This module assigns SSO Users to SSO Groups in the [AWS SSO Identity Source](https://docs.aws.amazon.com/singlesignon/latest/userguide/manage-your-identity-source.html).

## why

It is ideal to have all the processes of creating and assigning users and groups in code to reduce the manual work done in the console. This can be further extended to also support permission assignments. 