### PR TITLE
Fix SSO module

### DIFF
--- a/modules/account-assignments/main.tf
+++ b/modules/account-assignments/main.tf
@@ -22,9 +22,11 @@ data "aws_identitystore_user" "this" {
   for_each          = local.user_list
   identity_store_id = local.identity_store_id
 
-  filter {
-    attribute_path  = "UserName"
+  alternate_identifier {
+    unique_attribute {
+      attribute_path  = "UserName"
     attribute_value = each.key
+    }
   }
 
   depends_on = [null_resource.dependency]

--- a/modules/account-assignments/main.tf
+++ b/modules/account-assignments/main.tf
@@ -25,7 +25,7 @@ data "aws_identitystore_user" "this" {
   alternate_identifier {
     unique_attribute {
       attribute_path  = "UserName"
-    attribute_value = each.key
+      attribute_value = each.key
     }
   }
 


### PR DESCRIPTION
## what

Fix the deprecation warnings as described here: https://github.com/hashicorp/terraform-provider-aws/releases/tag/v4.40.0 for module.sso_account_assignments.data.aws_identitystore_user.this

## why
Otherwise there are deprecation error described in issue https://github.com/cloudposse/terraform-aws-sso/issues/38

## references

- https://github.com/hashicorp/terraform-provider-aws/releases/tag/v4.40.0
- https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/identitystore_group#filter
- closes - https://github.com/cloudposse/terraform-aws-sso/issues/38

