### PR TITLE
Adds defaults for variables so account assignment and permission sets can be written more simply.

### DIFF
--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -32,24 +32,23 @@ module "permission_sets" {
 module "sso_account_assignments" {
   source = "../../modules/account-assignments"
 
+  permission_sets = module.permission_sets.permission_sets
+
   account_assignments = [
     {
       account             = "111111111111", # Represents the "production" account
-      permission_set_arn  = module.permission_sets.permission_sets["AdministratorAccess"].arn,
       permission_set_name = "AdministratorAccess",
       principal_type      = "GROUP",
       principal_name      = "Administrators"
     },
     {
       account             = "111111111111",
-      permission_set_arn  = module.permission_sets.permission_sets["S3AdministratorAccess"].arn,
       permission_set_name = "S3AdministratorAccess",
       principal_type      = "GROUP",
       principal_name      = "S3Adminstrators"
     },
     {
       account             = "222222222222", # Represents the "Sandbox" account
-      permission_set_arn  = module.permission_sets.permission_sets["AdministratorAccess"].arn,
       permission_set_name = "AdministratorAccess",
       principal_type      = "GROUP",
       principal_name      = "Developers"

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -3,11 +3,12 @@ module "permission_sets" {
 
   permission_sets = [
     {
+      # one of inline_policy, policy_attachments or customer_managed_policy_attachments must be specified
       name               = "AdministratorAccess",
       description        = "Allow Full Access to the account",
-      relay_state        = "",
-      session_duration   = "",
-      tags               = {},
+      relay_state        = "", # default
+      session_duration   = "", # default is PT8H
+      tags               = {}, # default
       inline_policy      = "",
       policy_attachments = ["arn:aws:iam::aws:policy/AdministratorAccess"]
       customer_managed_policy_attachments = [{
@@ -24,7 +25,13 @@ module "permission_sets" {
       inline_policy                       = data.aws_iam_policy_document.S3Access.json,
       policy_attachments                  = []
       customer_managed_policy_attachments = []
-    }
+    },
+    {
+      # This is the bare minimum that must be specified
+      name                                = "AdministratorAccess",
+      description                         = "Allow Full Access",
+      policy_attachments                  = ["arn:aws:iam::aws:policy/AdministratorAccess"]
+    },
   ]
   context = module.this.context
 }
@@ -37,20 +44,20 @@ module "sso_account_assignments" {
   account_assignments = [
     {
       account             = "111111111111", # Represents the "production" account
+      # permission_set_arn is optional and will be looked up in the permission sets above if not specified
+      permission_set_arn  = module.permission_sets.permission_sets["AdministratorAccess"].arn,
       permission_set_name = "AdministratorAccess",
-      principal_type      = "GROUP",
+      principal_type      = "GROUP", # GROUP is the default, USER can also be specified
       principal_name      = "Administrators"
     },
     {
       account             = "111111111111",
       permission_set_name = "S3AdministratorAccess",
-      principal_type      = "GROUP",
       principal_name      = "S3Adminstrators"
     },
     {
       account             = "222222222222", # Represents the "Sandbox" account
       permission_set_name = "AdministratorAccess",
-      principal_type      = "GROUP",
       principal_name      = "Developers"
     },
   ]

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -31,7 +31,7 @@ module "permission_sets" {
       name                                = "AdministratorAccess",
       description                         = "Allow Full Access",
       policy_attachments                  = ["arn:aws:iam::aws:policy/AdministratorAccess"]
-    },
+    }
   ]
   context = module.this.context
 }

--- a/modules/account-assignments/main.tf
+++ b/modules/account-assignments/main.tf
@@ -41,7 +41,7 @@ resource "aws_ssoadmin_account_assignment" "this" {
   for_each = local.assignment_map
 
   instance_arn       = local.sso_instance_arn
-  permission_set_arn  = a.permission_set_name == "" ? var.permission_sets[a.permission_set_name].arn : a.permission_set_name
+  permission_set_arn  = a.permission_set_arn == "" ? var.permission_sets[a.permission_set_name].arn : a.permission_set_arn
 
 
   principal_id   = each.value.principal_type == "GROUP" ? data.aws_identitystore_group.this[each.value.principal_name].id : data.aws_identitystore_user.this[each.value.principal_name].id

--- a/modules/account-assignments/main.tf
+++ b/modules/account-assignments/main.tf
@@ -41,7 +41,8 @@ resource "aws_ssoadmin_account_assignment" "this" {
   for_each = local.assignment_map
 
   instance_arn       = local.sso_instance_arn
-  permission_set_arn = each.value.permission_set_arn
+  permission_set_arn  = a.permission_set_name == "" ? var.permission_sets[a.permission_set_name].arn : a.permission_set_name
+
 
   principal_id   = each.value.principal_type == "GROUP" ? data.aws_identitystore_group.this[each.value.principal_name].id : data.aws_identitystore_user.this[each.value.principal_name].id
   principal_type = each.value.principal_type

--- a/modules/account-assignments/variables.tf
+++ b/modules/account-assignments/variables.tf
@@ -2,9 +2,9 @@ variable "account_assignments" {
   type = list(object({
     account             = string
     permission_set_name = string
-    permission_set_arn  = string
+    permission_set_arn  = optional(string, "")
     principal_name      = string
-    principal_type      = string
+    principal_type      = optional(string, "GROUP")
   }))
 }
 
@@ -12,4 +12,8 @@ variable "identitystore_group_depends_on" {
   description = "A list of parameters to use for data resources to depend on. This is a workaround to avoid module depends_on as that will recreate the module resources in many unexpected situations"
   type        = list(string)
   default     = []
+}
+
+variable "permission_sets" {
+  type = map
 }

--- a/modules/permission-sets/variables.tf
+++ b/modules/permission-sets/variables.tf
@@ -1,16 +1,16 @@
 variable "permission_sets" {
   type = list(object({
     name               = string
-    description        = string
-    relay_state        = string
-    session_duration   = string
-    tags               = map(string)
-    inline_policy      = string
-    policy_attachments = list(string)
-    customer_managed_policy_attachments = list(object({
+    description        = optional(string, "")
+    relay_state        = optional(string, "")
+    session_duration   = optional(string, "PT8H")
+    tags               = optional(map(string), {})
+    inline_policy      = optional(string, "")
+    policy_attachments = optional(list(string), [])
+    customer_managed_policy_attachments = optional(list(object({
       name = string
       path = string
-    }))
+    })), [])
   }))
 
   default = []


### PR DESCRIPTION
## what

Adds defaults for variables so account assignment and permission sets can be written more simply.
Also does lookups for the permission sets so arn does not need to be specified.

## why

Simplies the account assignment and permission set

Examples
Able to turn this:
```
    {
      name                                = "AdministratorAccess",
      description                         = "Allow Full Admininstrator access to the account",
      relay_state                         = "",
      session_duration                    = "",
      tags                                = {},
      inline_policy                       = ""
      policy_attachments                  = ["arn:aws:iam::aws:policy/AdministratorAccess"]
      customer_managed_policy_attachments = []
    },
...
  account_assignments = [
    {
      account             = "111111111111", # Represents the "production" account
      permission_set_arn  = module.permission_sets.permission_sets["AdministratorAccess"].arn,
      permission_set_name = "AdministratorAccess",
      principal_type      = "GROUP", 
      principal_name      = "Administrators"
    },
...
```
Into this
```
    {
      name                                = "AdministratorAccess",
      description                         = "Allow Full Access",
      policy_attachments                  = ["arn:aws:iam::aws:policy/AdministratorAccess"]
    }
...
    {
      account             = "111111111111",
      permission_set_name = "AdministratorAccess",
      principal_name      = "Adminstrators"
    },

```
```
## references

