### PR TITLE
Add permission boundary attachment logic

### DIFF
--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -13,7 +13,8 @@ module "permission_sets" {
       customer_managed_policy_attachments = [{
         name = aws_iam_policy.S3Access.name
         path = aws_iam_policy.S3Access.path
-      }]
+      }],
+      boundary_policy_attachments = []
     },
     {
       name                                = "S3AdministratorAccess",
@@ -24,6 +25,7 @@ module "permission_sets" {
       inline_policy                       = data.aws_iam_policy_document.S3Access.json,
       policy_attachments                  = []
       customer_managed_policy_attachments = []
+      boundary_policy_attachments = []
     }
   ]
   context = module.this.context

--- a/modules/permission-sets/variables.tf
+++ b/modules/permission-sets/variables.tf
@@ -11,6 +11,10 @@ variable "permission_sets" {
       name = string
       path = string
     }))
+    boundary_policy_attachments = list(object({
+      name = string
+      path = string
+    }))  
   }))
 
   default = []


### PR DESCRIPTION
## what
This commit adds a variable and logic to attach permission boundaries to permission sets. 

## why
This functionality is useful in the context of deploying permission sets. 

## references
fixed #37 


## Notes
Just in time (?) provisioning for the boundary to the target account doesn't seem to work so the boundary policy needs to exist in the target account prior to attempting to attach it.