### PR TITLE
fix: coalesce policy attachments to '/'

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,12 +45,6 @@ source, and then use them for attribute-based access control in AWS.
 ---
 
 This project is part of our comprehensive ["SweetOps"](https://cpco.io/sweetops) approach towards DevOps.
-[<img align="right" title="Share via Email" src="https://docs.cloudposse.com/images/ionicons/ios-email-outline-2.0.1-16x16-999999.svg"/>][share_email]
-[<img align="right" title="Share on Google+" src="https://docs.cloudposse.com/images/ionicons/social-googleplus-outline-2.0.1-16x16-999999.svg" />][share_googleplus]
-[<img align="right" title="Share on Facebook" src="https://docs.cloudposse.com/images/ionicons/social-facebook-outline-2.0.1-16x16-999999.svg" />][share_facebook]
-[<img align="right" title="Share on Reddit" src="https://docs.cloudposse.com/images/ionicons/social-reddit-outline-2.0.1-16x16-999999.svg" />][share_reddit]
-[<img align="right" title="Share on LinkedIn" src="https://docs.cloudposse.com/images/ionicons/social-linkedin-outline-2.0.1-16x16-999999.svg" />][share_linkedin]
-[<img align="right" title="Share on Twitter" src="https://docs.cloudposse.com/images/ionicons/social-twitter-outline-2.0.1-16x16-999999.svg" />][share_twitter]
 
 
 
@@ -137,8 +131,6 @@ No outputs.
 
 Like this project? Please give it a ★ on [our GitHub](https://github.com/cloudposse/terraform-aws-sso)! (it helps us **a lot**)
 
-Are you using this project or any of our other projects? Consider [leaving a testimonial][testimonial]. =)
-
 
 
 ## Related Projects
@@ -192,10 +184,6 @@ We deliver 10x the value for a fraction of the cost of a full-time engineer. Our
 
 Join our [Open Source Community][slack] on Slack. It's **FREE** for everyone! Our "SweetOps" community is where you get to talk with others who share a similar vision for how to rollout and manage infrastructure. This is the best place to talk shop, ask questions, solicit feedback, and work together as a community to build totally *sweet* infrastructure.
 
-## Discourse Forums
-
-Participate in our [Discourse Forums][discourse]. Here you'll find answers to commonly asked questions. Most questions will be related to the enormous number of projects we support on our GitHub. Come here to collaborate on answers, find solutions, and get ideas about the products and services we value. It only takes a minute to get started! Just sign in with SSO using your GitHub account.
-
 ## Newsletter
 
 Sign up for [our newsletter][newsletter] that covers everything on our technology radar.  Receive updates on what we're up to on GitHub as well as awesome new projects we discover.
@@ -206,7 +194,18 @@ Sign up for [our newsletter][newsletter] that covers everything on our technolog
 
 [![zoom](https://img.cloudposse.com/fit-in/200x200/https://cloudposse.com/wp-content/uploads/2019/08/Powered-by-Zoom.png")][office_hours]
 
-## Contributing
+## ✨ Contributing
+
+
+
+This project is under active development, and we encourage contributions from our community. 
+Many thanks to our outstanding contributors:
+
+<a href="https://github.com/cloudposse/terraform-aws-sso/graphs/contributors">
+  <img src="https://contrib.rocks/image?repo=cloudposse/terraform-aws-sso&max=24" />
+</a>
+
+
 
 ### Bug Reports & Feature Requests
 
@@ -283,21 +282,7 @@ We're a [DevOps Professional Services][hire] company based in Los Angeles, CA. W
 
 We offer [paid support][commercial_support] on all of our projects.
 
-Check out [our other projects][github], [follow us on twitter][twitter], [apply for a job][jobs], or [hire us][hire] to help with your cloud strategy and implementation.
-
-
-
-### Contributors
-
-<!-- markdownlint-disable -->
-|  [![Matt Calhoun][mcalhoun_avatar]][mcalhoun_homepage]<br/>[Matt Calhoun][mcalhoun_homepage] |
-|---|
-<!-- markdownlint-restore -->
-
-  [mcalhoun_homepage]: https://github.com/mcalhoun
-  [mcalhoun_avatar]: https://img.cloudposse.com/150x150/https://github.com/mcalhoun.png
-
-[![README Footer][readme_footer_img]][readme_footer_link]
+Check out [our other projects][github], [follow us on twitter][twitter], [apply for a job][jobs], or [hire us][hire] to help with your cloud strategy and implementation.[![README Footer][readme_footer_img]][readme_footer_link]
 [![Beacon][beacon]][website]
 <!-- markdownlint-disable -->
   [logo]: https://cloudposse.com/logo-300x69.svg
@@ -307,12 +292,10 @@ Check out [our other projects][github], [follow us on twitter][twitter], [apply 
   [jobs]: https://cpco.io/jobs?utm_source=github&utm_medium=readme&utm_campaign=cloudposse/terraform-aws-sso&utm_content=jobs
   [hire]: https://cpco.io/hire?utm_source=github&utm_medium=readme&utm_campaign=cloudposse/terraform-aws-sso&utm_content=hire
   [slack]: https://cpco.io/slack?utm_source=github&utm_medium=readme&utm_campaign=cloudposse/terraform-aws-sso&utm_content=slack
-  [linkedin]: https://cpco.io/linkedin?utm_source=github&utm_medium=readme&utm_campaign=cloudposse/terraform-aws-sso&utm_content=linkedin
   [twitter]: https://cpco.io/twitter?utm_source=github&utm_medium=readme&utm_campaign=cloudposse/terraform-aws-sso&utm_content=twitter
   [testimonial]: https://cpco.io/leave-testimonial?utm_source=github&utm_medium=readme&utm_campaign=cloudposse/terraform-aws-sso&utm_content=testimonial
   [office_hours]: https://cloudposse.com/office-hours?utm_source=github&utm_medium=readme&utm_campaign=cloudposse/terraform-aws-sso&utm_content=office_hours
   [newsletter]: https://cpco.io/newsletter?utm_source=github&utm_medium=readme&utm_campaign=cloudposse/terraform-aws-sso&utm_content=newsletter
-  [discourse]: https://ask.sweetops.com/?utm_source=github&utm_medium=readme&utm_campaign=cloudposse/terraform-aws-sso&utm_content=discourse
   [email]: https://cpco.io/email?utm_source=github&utm_medium=readme&utm_campaign=cloudposse/terraform-aws-sso&utm_content=email
   [commercial_support]: https://cpco.io/commercial-support?utm_source=github&utm_medium=readme&utm_campaign=cloudposse/terraform-aws-sso&utm_content=commercial_support
   [we_love_open_source]: https://cpco.io/we-love-open-source?utm_source=github&utm_medium=readme&utm_campaign=cloudposse/terraform-aws-sso&utm_content=we_love_open_source
@@ -323,11 +306,5 @@ Check out [our other projects][github], [follow us on twitter][twitter], [apply 
   [readme_footer_link]: https://cloudposse.com/readme/footer/link?utm_source=github&utm_medium=readme&utm_campaign=cloudposse/terraform-aws-sso&utm_content=readme_footer_link
   [readme_commercial_support_img]: https://cloudposse.com/readme/commercial-support/img
   [readme_commercial_support_link]: https://cloudposse.com/readme/commercial-support/link?utm_source=github&utm_medium=readme&utm_campaign=cloudposse/terraform-aws-sso&utm_content=readme_commercial_support_link
-  [share_twitter]: https://twitter.com/intent/tweet/?text=terraform-aws-sso&url=https://github.com/cloudposse/terraform-aws-sso
-  [share_linkedin]: https://www.linkedin.com/shareArticle?mini=true&title=terraform-aws-sso&url=https://github.com/cloudposse/terraform-aws-sso
-  [share_reddit]: https://reddit.com/submit/?url=https://github.com/cloudposse/terraform-aws-sso
-  [share_facebook]: https://facebook.com/sharer/sharer.php?u=https://github.com/cloudposse/terraform-aws-sso
-  [share_googleplus]: https://plus.google.com/share?url=https://github.com/cloudposse/terraform-aws-sso
-  [share_email]: mailto:?subject=terraform-aws-sso&body=https://github.com/cloudposse/terraform-aws-sso
   [beacon]: https://ga-beacon.cloudposse.com/UA-76589703-4/cloudposse/terraform-aws-sso?pixel&cs=github&cm=readme&an=terraform-aws-sso
 <!-- markdownlint-restore -->

--- a/examples/complete/versions.tf
+++ b/examples/complete/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.13.0"
+  required_version = ">= 1.3.0"
 
   required_providers {
     local = "~> 1.2"

--- a/modules/permission-sets/main.tf
+++ b/modules/permission-sets/main.tf
@@ -40,7 +40,7 @@ resource "aws_ssoadmin_customer_managed_policy_attachment" "this" {
   permission_set_arn = aws_ssoadmin_permission_set.this[each.value.policy_set].arn
   customer_managed_policy_reference {
     name = each.value.policy_name
-    path = each.value.policy_path
+    path = coalesce(each.value.policy_path, "/")
   }
 }
 

--- a/modules/permission-sets/variables.tf
+++ b/modules/permission-sets/variables.tf
@@ -14,8 +14,4 @@ variable "permission_sets" {
   }))
 
   default = []
-  validation {
-    error_message = "Customer managed policy attachment path cannot be empty"
-    condition     = !anytrue([for ps in var.permission_sets : anytrue([for p in ps.customer_managed_policy_attachments : p.path == ""])])
-  }
 }

--- a/modules/permission-sets/variables.tf
+++ b/modules/permission-sets/variables.tf
@@ -9,9 +9,13 @@ variable "permission_sets" {
     policy_attachments = list(string)
     customer_managed_policy_attachments = list(object({
       name = string
-      path = string
+      path = optional(string, "/")
     }))
   }))
 
   default = []
+  validation {
+    error_message = "Customer managed policy attachment path cannot be empty"
+    condition     = !anytrue([for ps in var.permission_sets : anytrue([for p in ps.customer_managed_policy_attachments : p.path == ""])])
+  }
 }

--- a/modules/permission-sets/versions.tf
+++ b/modules/permission-sets/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.13.0"
+  required_version = ">= 1.3.0"
 
   required_providers {
     aws = {


### PR DESCRIPTION
## what

- coalesce policy attachments in `parameter-set` module to `"/"`

## why

- Some versions of the aws-sso provider allow this behavior and it corrupts
tfstate
- coalesce is more friendly to generated paths, which could be difficult to correct in some scenarios