### PR TITLE
fix: require deterministic values for the for loop from var.account_assignments

### DIFF
--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -34,21 +34,24 @@ module "sso_account_assignments" {
 
   account_assignments = [
     {
-      account             = "111111111111", # Represents the "production" account
+      account_id          = "111111111111", # Represents the "production" account
+      account_name        = "Account1"
       permission_set_arn  = module.permission_sets.permission_sets["AdministratorAccess"].arn,
       permission_set_name = "AdministratorAccess",
       principal_type      = "GROUP",
       principal_name      = "Administrators"
     },
     {
-      account             = "111111111111",
+      account_id          = "111111111111",
+      account_name        = "Account1"
       permission_set_arn  = module.permission_sets.permission_sets["S3AdministratorAccess"].arn,
       permission_set_name = "S3AdministratorAccess",
       principal_type      = "GROUP",
       principal_name      = "S3Adminstrators"
     },
     {
-      account             = "222222222222", # Represents the "Sandbox" account
+      account_id          = "222222222222", # Represents the "Sandbox" account
+      account_name        = "account2"
       permission_set_arn  = module.permission_sets.permission_sets["AdministratorAccess"].arn,
       permission_set_name = "AdministratorAccess",
       principal_type      = "GROUP",

--- a/examples/complete/versions.tf
+++ b/examples/complete/versions.tf
@@ -2,6 +2,6 @@ terraform {
   required_version = ">= 1.3.0"
 
   required_providers {
-    local = "~> 1.2"
+    local = "~> 2.4.1"
   }
 }

--- a/modules/account-assignments/main.tf
+++ b/modules/account-assignments/main.tf
@@ -35,7 +35,7 @@ data "aws_identitystore_user" "this" {
 locals {
   assignment_map = {
     for a in var.account_assignments :
-    format("%v-%v-%v-%v", a.account, substr(a.principal_type, 0, 1), a.principal_name, a.permission_set_name) => a
+    format("%v-%v-%v-%v", a.account_name, substr(a.principal_type, 0, 1), a.principal_name, a.permission_set_name) => a
   }
 }
 
@@ -48,7 +48,7 @@ resource "aws_ssoadmin_account_assignment" "this" {
   principal_id   = each.value.principal_type == "GROUP" ? data.aws_identitystore_group.this[each.value.principal_name].id : data.aws_identitystore_user.this[each.value.principal_name].id
   principal_type = each.value.principal_type
 
-  target_id   = each.value.account
+  target_id   = each.value.account_id
   target_type = "AWS_ACCOUNT"
 }
 

--- a/modules/account-assignments/variables.tf
+++ b/modules/account-assignments/variables.tf
@@ -1,10 +1,11 @@
 variable "account_assignments" {
   type = list(object({
-    account             = string
-    permission_set_name = string
-    permission_set_arn  = string
-    principal_name      = string
-    principal_type      = string
+    account_name        = string // has to be determined value before terraform apply
+    account_id          = string // can be determined later
+    permission_set_name = string // has to be determined value before terraform apply
+    permission_set_arn  = string // can be determined later
+    principal_name      = string // has to be determined value before terraform apply
+    principal_type      = string // has to be determined value before terraform apply
   }))
 }
 


### PR DESCRIPTION
## what

<!--
- Describe high-level what changed as a result of these commits (i.e. in plain-english, what do these changes mean?)
- Use bullet points to be concise and to the point.
-->
Major fix:
Make local.assignment_map to be compiled from account_name instead of account id.

Minor fix:
Upgrade terraform local provider in examples to the latest version to make it working for Apple M1 chip platform.

## why

<!--
- Provide the justifications for the changes (e.g. business case). 
- Describe why these changes were made (e.g. why do these commits fix the problem?)
- Use bullet points to be concise and to the point.
-->
The error:
```
Error: Invalid for_each argument
on .terraform/modules/sso_account_assignments/modules/account-assignments/main.tf line 29, in resource "aws_ssoadmin_account_assignment" "this":
  for_each = local.assignment_map
local.assignment_map will be known only after apply
```
In my use case, I am creating the AWS account within the same workspace of the SSO assignments. So, the input `var.account_assignments[*].account`(which is the account id) is not known until the resource is getting created. Thus, the local.assignment_map cannot be determined at terraform compiling stage, and the `for_each` loop on the `local.assignment_map` in `resource.aws_ssoadmin_account_assignment.this` can not be determined either. 

However, the account name is something people can predefine before the aws account is created. So include the account name in the input var.account_assignments, and use the `a.account_name` which is deterministic, instead of `a.account`(`account_id`) will resolve this issue.

## references

<!--
- Link to any supporting github issues or helpful documentation to add some context (e.g. stackoverflow). 
- Use `closes #123`, if this PR closes a GitHub issue `#123`
-->
