### PR TITLE
feat(account-assignments): add var.group_ids to skip data lookup for known groups

### DIFF
--- a/modules/account-assignments/main.tf
+++ b/modules/account-assignments/main.tf
@@ -5,7 +5,11 @@ resource "null_resource" "dependency" {
 }
 
 data "aws_identitystore_group" "this" {
-  for_each          = local.group_list
+  # Look up only groups NOT provided via var.group_ids. Groups passed in by
+  # the parent module (Terraform-managed + already-resolved IdP groups) skip
+  # this data source, avoiding ResourceNotFoundException at plan time when
+  # the group is yet to be created.
+  for_each          = local.group_list_to_lookup
   identity_store_id = local.identity_store_id
 
   alternate_identifier {
@@ -45,7 +49,7 @@ resource "aws_ssoadmin_account_assignment" "this" {
   instance_arn       = local.sso_instance_arn
   permission_set_arn = each.value.permission_set_arn
 
-  principal_id   = each.value.principal_type == "GROUP" ? data.aws_identitystore_group.this[each.value.principal_name].id : data.aws_identitystore_user.this[each.value.principal_name].id
+  principal_id   = each.value.principal_type == "GROUP" ? local.resolved_group_ids[each.value.principal_name] : data.aws_identitystore_user.this[each.value.principal_name].id
   principal_type = each.value.principal_type
 
   target_id   = each.value.account
@@ -63,7 +67,17 @@ locals {
   identity_store_id = tolist(data.aws_ssoadmin_instances.this.identity_store_ids)[0]
   sso_instance_arn  = tolist(data.aws_ssoadmin_instances.this.arns)[0]
 
-  group_list = toset([for mapping in var.account_assignments : mapping.principal_name if mapping.principal_type == "GROUP"])
-  user_list  = toset([for mapping in var.account_assignments : mapping.principal_name if mapping.principal_type == "USER"])
+  group_list           = toset([for mapping in var.account_assignments : mapping.principal_name if mapping.principal_type == "GROUP"])
+  group_list_to_lookup = setsubtract(local.group_list, toset(keys(var.group_ids)))
+  user_list            = toset([for mapping in var.account_assignments : mapping.principal_name if mapping.principal_type == "USER"])
+
+  # Group IDs come from two sources, in order of precedence:
+  #   1. var.group_ids — passed explicitly by the parent module (skips data lookup)
+  #   2. data.aws_identitystore_group.this — fallback for groups not in var.group_ids
+  # Merge gives a complete display_name → id map for principal_id resolution.
+  resolved_group_ids = merge(
+    var.group_ids,
+    { for k, v in data.aws_identitystore_group.this : k => v.id },
+  )
 }
 

--- a/modules/account-assignments/variables.tf
+++ b/modules/account-assignments/variables.tf
@@ -15,3 +15,19 @@ variable "identitystore_group_depends_on" {
   type        = list(string)
   default     = []
 }
+
+variable "group_ids" {
+  description = <<-EOT
+    Map of group display name to Identity Store group ID. When provided, the
+    submodule resolves GROUP principals from this map directly instead of
+    using a data source. This avoids a `ResourceNotFoundException` at plan
+    time when an `account_assignments` entry references a Terraform-managed
+    group that has not yet been created.
+
+    Pass a merged map of all manual + IdP group IDs from the parent module.
+    Any principal_name in `account_assignments` that is missing from this map
+    falls back to the data source lookup, preserving the previous behavior.
+    EOT
+  type        = map(string)
+  default     = {}
+}


### PR DESCRIPTION
This is a continuation of the changes on identity center component. This code is running on my environment with IdP groups and local groups mixed.
Tested by a human

## what

Adds an optional `var.group_ids` map (display_name → group_id) input to the
`account-assignments` submodule. When provided, the submodule resolves
`GROUP` principals from this map directly instead of issuing a
`data.aws_identitystore_group.this` lookup.

## why

At plan time the existing data source iterates every group display name in
`var.account_assignments`. If any of those groups is a Terraform-managed
group that has not yet been created, the lookup fails:

```
Error: reading IdentityStore Group ...: ResourceNotFoundException: GROUP not found.
```

This blocks a fairly common pattern: declare a TF-managed group via
`aws_identitystore_group` in the parent module **and** reference it in
`account_assignments` in the same apply.

Existing workarounds are all bad:

- **Two-phase apply** — add the group, apply, then add the assignment, apply.
- **Bypass the module** with custom `aws_ssoadmin_account_assignment`
  resources, losing the value of the submodule.
- **Module-level `depends_on`** — caused cascading destroy/recreate of every
  permission set and existing assignment. Removed in
  [cloudposse-terraform-components/aws-identity-center#74](https://github.com/cloudposse-terraform-components/aws-identity-center/pull/74).

The narrower `identitystore_group_depends_on` workaround inside this
submodule has the same root issue: when group IDs are unknown at plan time,
`null_resource.dependency.triggers` becomes `(known after apply)`, every
data source defers, every dependent assignment's `principal_id` becomes
`(known after apply)`, and because that field is `ForceNew`, every existing
assignment is destroyed and recreated.

## what changed

- New variable `group_ids` (`map(string)`, default `{}`). Empty map preserves
  the previous behavior — fully backward compatible.
- `data.aws_identitystore_group.this` now iterates
  `local.group_list_to_lookup`, the set difference of the original
  `group_list` and `keys(var.group_ids)`.
- `aws_ssoadmin_account_assignment.this.principal_id` resolves GROUP
  principals via `local.resolved_group_ids` — a merge of `var.group_ids`
  and the surviving data-source results.

```
 modules/account-assignments/main.tf      | 22 ++++++++++++++++++----
 modules/account-assignments/variables.tf | 16 ++++++++++++++++
 2 files changed, 34 insertions(+), 4 deletions(-)
```

## backward compatibility

- Default `group_ids = {}` reproduces existing behavior exactly. No code
  change required from current consumers.
- Existing `identitystore_group_depends_on` + `null_resource.dependency`
  workaround is left untouched.
- No state migration required.
- No provider version bump required.

## test plan

Validated against a real CloudPosse `aws-identity-center` component in a
production-style stack with mixed Terraform-managed + SCIM groups across
9 AWS accounts:

| Scenario | Result |
|---|---|
| Without fix, TF-managed group in `account_assignments` | `Error: ResourceNotFoundException: GROUP not found` |
| With fix, parent passes merged `group_ids` map | `Plan: 12 to add, 0 to change, 0 to destroy` |
| Existing ~20 SCIM-group assignments | `0 to change` — no spurious diffs |
| Existing ~15 permission sets | `0 to change` — no cascade |

- [x] `terraform fmt -recursive`
- [x] `terraform validate` on `modules/account-assignments`
- [x] CI: `terratest`, `pre-commit`

## pairs with

A follow-up PR in `cloudposse-terraform-components/aws-identity-center`
wires the parent module to pass a merged manual + IdP `group_ids` map. Will
link here once opened.